### PR TITLE
Fixing drag n drop in FireFox and outside the browser in IE

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -438,14 +438,26 @@ SyntheticEvent syntheticFormEventFactory(JsObject e) {
 SyntheticDataTransfer syntheticDataTransferFactory(JsObject dt) {
   if (dt == null) return null;
   List<File> files = [];
-  for (int i = 0; i < dt["files"]["length"]; i++) {
-    files.add(dt["files"][i]);
+  if (dt["files"] != null) {
+    for (int i = 0; i < dt["files"]["length"]; i++) {
+      files.add(dt["files"][i]);
+    }
   }
   List<String> types = [];
-  for (int i = 0; i < dt["types"]["length"]; i++) {
-    types.add(dt["types"][i]);
+  if (dt["types"] != null) {
+    for (int i = 0; i < dt["types"]["length"]; i++) {
+      types.add(dt["types"][i]);
+    }
   }
-  return new SyntheticDataTransfer(dt["dropEffect"], dt["effectAllowed"], files, types);
+  var effectAllowed;
+  try {
+    // Works around a bug in IE where dragging from outside the browser fails.
+    // Trying to access this property throws the error "Unexpected call to method or property access.".
+    effectAllowed = dt["effectAllowed"];
+  } catch (exception) {
+    effectAllowed = "uninitialized";
+  }
+  return new SyntheticDataTransfer(dt["dropEffect"], effectAllowed, files, types);
 }
 
 SyntheticEvent syntheticMouseEventFactory(JsObject e) {


### PR DESCRIPTION
  In FireFox, Dragging would sometimes leave files and types null instead of a 0 length array.
  In IE, Dragging from outside the browser would cause an exception when the property dataTransfer.effectAllowed was accessed.
