### PR TITLE
Fix incorrect closings of unpaired tags

### DIFF
--- a/lib/react_server.dart
+++ b/lib/react_server.dart
@@ -276,9 +276,7 @@ Set _pairElements = new Set.from(["a", "abbr", "address", "article", "aside", "a
  * set of empty elements tags based on http://www.w3.org/TR/html-markup/syntax.html#void-element
  */
 Set _unPairElements = new Set.from(["area", "base", "br", "col", "hr", "img", "input", "link",
-    "meta", "param", "command", "embed", "keygen", "source","track", "wbr",
-    /** SVG elements */
-    "circle", "ellipse", "line", "path", "polygon", "polyline", "rect", "stop",]);
+    "meta", "param", "command", "embed", "keygen", "source","track", "wbr"]);
 
 
 /**


### PR DESCRIPTION
It works in HTML, but fails with SVG, which should be an XML document.
Let's use the closing tag format, which works both with XML and HTML.
