### PR TITLE
Remove forcing of lowercase attribute keys

### DIFF
--- a/lib/react_server.dart
+++ b/lib/react_server.dart
@@ -232,7 +232,7 @@ String _parseDomArgument(String key, dynamic value) {
   }
 
   value = _escapeTextForBrowser(value);
-  return " ${key.toLowerCase()}=\"${value}\"";
+  return " ${key}=\"${value}\"";
 }
 
 var _ESCAPE_LOOKUP = {


### PR DESCRIPTION
In SVG, for example, 'viewbox' is an invalid attribute, and will be
ignored by a browser, but 'viewBox' is valid.
